### PR TITLE
content-detail 모달창 DTO, service 구현

### DIFF
--- a/src/main/java/com/project/ohflix/domain/content/ContentResponse.java
+++ b/src/main/java/com/project/ohflix/domain/content/ContentResponse.java
@@ -134,7 +134,7 @@ public class ContentResponse {
         }
     }
 
-    // 메인  상세 정보 페이지 + 찜 여부
+    // 메인  상세 정보 페이지 + 찜 여부 + 좋아요 여부
     @Data
     public static class MainContent {
         private Integer id;
@@ -153,8 +153,9 @@ public class ContentResponse {
         private String director;
 
         private boolean isFavorite;
+        private boolean isLike;
 
-        public MainContent(Content content, boolean isFavorite) {
+        public MainContent(Content content, boolean isFavorite, boolean isLike) {
             this.id = content.getId();
             this.mainPhoto = content.getMainPhoto();
             this.title = content.getTitle();
@@ -170,7 +171,8 @@ public class ContentResponse {
             this.characteristics = content.getCharacteristic();
             this.introduction = content.getIntroduction();
 
-            this.isFavorite = isFavorite;
+            this.isFavorite = isFavorite; // 찜 여부
+            this.isLike = isLike; // 좋아요 여부
         }
     }
 

--- a/src/main/java/com/project/ohflix/domain/content/ContentService.java
+++ b/src/main/java/com/project/ohflix/domain/content/ContentService.java
@@ -1,6 +1,8 @@
 package com.project.ohflix.domain.content;
 
 import com.project.ohflix._core.error.exception.Exception404;
+import com.project.ohflix.domain.like.Like;
+import com.project.ohflix.domain.like.LikeRepository;
 import com.project.ohflix.domain.mylist.MyList;
 import com.project.ohflix.domain.mylist.MyListRepository;
 import com.project.ohflix.domain.mylist.MyListResponse;
@@ -18,6 +20,7 @@ import java.util.Optional;
 public class ContentService {
     private final ContentRepository contentRepository;
     private final MyListRepository myListRepository;
+    private final LikeRepository likeRepository;
 
     // main page data
     public ContentResponse.MainPageDTO getMainPageData() {
@@ -75,19 +78,34 @@ public class ContentService {
         return new ContentResponse.DetailsDTO(content);
     }
 
+
+    // 영화 상세정보 페이지 + 찜 여부 + 좋아요 여부 데이터
     public ContentResponse.MainContent getMainContent(Integer sessionUserId, Integer contentId) {
         Content content = contentRepository.findById(contentId)
                 .orElseThrow(() -> new Exception404("정보를 찾을 수 없습니다."));
-        Optional<MyList> like = myListRepository.findByUserIdAndContentId(sessionUserId, contentId);
+
+        // 찜 여부
+        Optional<MyList> favorite = myListRepository.findByUserIdAndContentId(sessionUserId, contentId);
         boolean isFavorite;
-        if (like.isPresent()) {
+        if (favorite.isPresent()) {
             isFavorite = true;
         } else {
             isFavorite = false;
         }
 
-        return new ContentResponse.MainContent(content, isFavorite);
+        // 좋아요 여부
+        Optional<Like> like = likeRepository.findByUserIdAndContentId(sessionUserId, contentId);
+        boolean isLike;
+        if (like.isPresent()) {
+            isLike = true;
+        } else {
+            isLike = false;
+        }
+
+
+        return new ContentResponse.MainContent(content, isFavorite, isLike);
     }
+
 
     // 메인 페이지 영화 상세정보 가져오는 모달 - 비동기 통신
     public ContentResponse.DetailsDTO getContentInfo(Integer contentId) {

--- a/src/main/java/com/project/ohflix/domain/like/LikeRequest.java
+++ b/src/main/java/com/project/ohflix/domain/like/LikeRequest.java
@@ -11,7 +11,7 @@ public class LikeRequest {
     public static class AddLikeDTO {
         private Integer userId;
         private Integer contentId;
-        private Timestamp createdAt;
+
     }
 
     // 좋아요 취소
@@ -19,6 +19,6 @@ public class LikeRequest {
     public static class RemoveLikeDTO {
         private Integer userId;
         private Integer contentId;
-        private Timestamp createdAt;
+
     }
 }

--- a/src/main/java/com/project/ohflix/domain/like/LikeResponse.java
+++ b/src/main/java/com/project/ohflix/domain/like/LikeResponse.java
@@ -18,12 +18,12 @@ public class LikeResponse {
     public static class AddLikeDTO {
         private int userId;
         private int contentId;
-        private Timestamp createdAt;
+
 
         public AddLikeDTO(LikeRequest.AddLikeDTO reqDTO) {
             this.userId = reqDTO.getUserId();
             this.contentId = reqDTO.getContentId();
-            this.createdAt = reqDTO.getCreatedAt();
+
         }
     }
 
@@ -33,12 +33,12 @@ public class LikeResponse {
     public static class RemoveLikeDTO {
         private int userId;
         private int contentId;
-        private Timestamp createdAt;
+
 
         public RemoveLikeDTO(LikeRequest.RemoveLikeDTO reqDTO) {
             this.userId = reqDTO.getUserId();
             this.contentId = reqDTO.getContentId();
-            this.createdAt = reqDTO.getCreatedAt();
+
         }
     }
 }

--- a/src/main/java/com/project/ohflix/domain/like/LikeService.java
+++ b/src/main/java/com/project/ohflix/domain/like/LikeService.java
@@ -38,7 +38,7 @@ public class LikeService {
         Like like = new Like();
         like.setUser(user);
         like.setContent(content);
-        like.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
         likeRepository.save(like);
 
         return new LikeResponse.AddLikeDTO(reqDTO);

--- a/src/main/resources/templates/_components/content-detail.mustache
+++ b/src/main/resources/templates/_components/content-detail.mustache
@@ -58,9 +58,11 @@
                                 <div class="buttons">
                                     <a href="#" class="play-button">▶ 재생</a>
                                     <button id="favoriteButton" class="icon">
-                                        ${data.response.isFavorite ? '<i class="fa-regular fa-circle-check"></i>' : '<i class="fa-solid fa-plus"></i>'}
+                                        ${data.response.isFavorite ? '<i class="fa-solid fa-check"></i></i>' : '<i class="fa-solid fa-plus"></i>'}
                                     </button>
-                                    <a href="#" class="icon"><i class="fa-regular fa-thumbs-up"></i></a>
+                                    <button id="likeButton" class="icon">
+                                        ${data.response.isLike ? '<i class="fa-solid fa-thumbs-up"></i>' : '<i class="fa-regular fa-thumbs-up"></i>'}
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -110,6 +112,12 @@
                         favoriteButton.addEventListener('click', function () {
                             toggleFavorite(contentId, data.response.isFavorite, favoriteButton);
                         });
+
+                        // 좋아요/좋아요취소 버튼 클릭 이벤트 핸들러 추가
+                        const likeButton = document.getElementById('likeButton');
+                        likeButton.addEventListener('click', function () {
+                            toggleLike(contentId, data.response.isLike, likeButton);
+                        });
                     })
                     .catch(error => {
                         modalData.innerText = 'Error loading data';
@@ -125,13 +133,35 @@
                             // 찜 상태를 반대로 변경
                             const newIsFavorite = !isFavorite;
                             // 버튼 아이콘 업데이트
-                            favoriteButton.innerHTML = newIsFavorite ? '<i class="fa-regular fa-circle-check"></i>' : '<i class="fa-solid fa-plus"></i>';
+                            favoriteButton.innerHTML = newIsFavorite ? '<i class="fa-solid fa-check"></i></i>' : '<i class="fa-solid fa-plus"></i>';
                             // 다음 클릭 시의 상태를 업데이트
                             favoriteButton.onclick = function () {
                                 toggleFavorite(contentId, newIsFavorite, favoriteButton);
                             };
                         } else {
                             console.error('Failed to update favorite status');
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                    });
+        }
+
+        function toggleLike(contentId, isLike, likeButton) {
+            const url = isLike ? `/api/users/${contentId}/dislike` : `/api/users/${contentId}/like`;
+            fetch(url, { method: 'POST' })
+                    .then(response => {
+                        if (response.ok) {
+                            // 찜 상태를 반대로 변경
+                            const newIsLike = !isLike;
+                            // 버튼 아이콘 업데이트
+                            likeButton.innerHTML = newIsLike ? '<i class="fa-solid fa-thumbs-up"></i>' : '<i class="fa-regular fa-thumbs-up"></i>';
+                            // 다음 클릭 시의 상태를 업데이트
+                            likeButton.onclick = function () {
+                                toggleLike(contentId, newIsLike, likeButton);
+                            };
+                        } else {
+                            console.error('Failed to update like status');
                         }
                     })
                     .catch(error => {


### PR DESCRIPTION
# content-detail 모달창 DTO, service 구현
- 찜 기능과 똑같은 문제점 有
- TODO : 모달 창을 껐다 켰을 때 isLike 값 반영 안되는 문제
    - 예를 들어
    1. 좋아요 눌렀을 때 Like 테이블에 추가됨
    2. 모달 창 껐다가 다시 켜면 좋아요 버튼이 색칠 안된 따봉(좋아요 안 했을 때 뜨는 버튼)이 뜸 좋아요 했는데도!!
    3. 버튼이 색칠X 따봉인 상태에서 다시 눌렀다가 색칠O 따봉으로 바뀐 뒤에 다시 누르면 색칠X 따봉으로 바뀌면서 Like 테이블에서 삭제됨