### PR TITLE
결제 내역이나 카드 정보가 없는 유저일 때 멤버십 상세정보 페이지 에러 해결

### DIFF
--- a/src/main/java/com/project/ohflix/domain/user/UserResponse.java
+++ b/src/main/java/com/project/ohflix/domain/user/UserResponse.java
@@ -264,8 +264,16 @@ public class UserResponse {
             this.userId = user.getId();
             this.profileIconId = user.getProfileIcon().getId();
             this.profileIconPath = user.getProfileIcon().getPath();
-            this.servicePeriod = extractEndDate(purchaseHistory.getServicePeriod());
-            this.lastDigit = cardInfo.getLastDigit();
+            if (purchaseHistory != null) {
+                this.servicePeriod = extractEndDate(purchaseHistory.getServicePeriod());
+            } else {
+                this.servicePeriod = "";
+            }
+            if (cardInfo != null) {
+                this.lastDigit = cardInfo.getLastDigit();
+            } else {
+                this.lastDigit = "";
+            }
         }
 
     }

--- a/src/main/java/com/project/ohflix/domain/user/UserService.java
+++ b/src/main/java/com/project/ohflix/domain/user/UserService.java
@@ -226,10 +226,10 @@ public class UserService {
         User user = userRepository.findUsernameAndIcon(sessionUserId).orElseThrow(() -> new Exception404("사용자 정보를 찾을 수 없습니다."));
 
         // 결제 내역 찾기
-        PurchaseHistory purchaseHistory = purchaseHistoryRepository.findById(sessionUserId).orElseThrow(() -> new Exception404("사용자 정보를 찾을 수 없습니다."));
+        PurchaseHistory purchaseHistory = purchaseHistoryRepository.findById(sessionUserId).orElse(null);
 
         // 카드 정보 찾기
-        CardInfo cardInfo = cardInfoRepository.findUserInfo(sessionUserId).orElseThrow(() -> new Exception404("사용자 정보를 찾을 수 없습니다."));
+        CardInfo cardInfo = cardInfoRepository.findUserInfo(sessionUserId).orElse(null);
 
         return new UserResponse.AccountMembershipDTO(user, purchaseHistory, cardInfo);
     }


### PR DESCRIPTION
# /api/account-membership
- orElse(null)
- responseDTO if문 추가